### PR TITLE
added ability to specify a comment title

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: __tests__
           terraform-plan-file: ../test-plan.tfplan
+          comment-title: Terraform Plan in different dir
 
   test-action-without-tf-wrapper: # make sure the action works without the terraform wrapper
     name: Test without TF wrapper
@@ -66,6 +67,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: __tests__
           terraform-plan-file: test-plan.tfplan
+          comment-title: Terraform Plan without wrapper
 
   test-action-at-root: # make sure the action works with terraform dir as root dir
     name: Test from Root
@@ -84,3 +86,4 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           terraform-plan-file: test-plan.tfplan
+          comment-title: Terraform Plan from root

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ jobs:
 * `github-token` - (**required**) pass in the GitHub token to make comments on the PR
 * `working-directory` - (_optional_) the directory of the terraform configuration files (defaults to `.`)
 * `terraform-plan-file` - (**required**) Filename of the terraform plan (relative to `working-directory`)
+* `comment-title` - (_optional_) Title for the comment this action will make on your pull request (defaults to `Terraform Plan`)
+    
+**note**: the `comment-title` is used to determine which PR comment to update.
+For instance if you have two of these actions in one PR with the same `comment-title` then they will both try to update the same comment.
 
 ## Output
 This action will create a comment on your PR like:
@@ -53,7 +57,9 @@ GitHub Actions will run the entry point from the action.yml.
 In our case, that happens to be /dist/index.js.
 
 Actions run from GitHub repos.
-We don't want to check in node_modules. Hence, we package the app using `yarn run pack`.
+We don't want to check in node_modules. 
+Hence, we package the app using `yarn run pack`.
+Make sure you run `yarn run pack` before committing/pushing.
 
 ### Modifying Source Code
 Just run `yarn install` locally.

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -8,6 +8,18 @@ const pr: PullRequest = {
   body: '',
   html_url: ''
 }
+const basicTestPlan: TerraformPlan = {
+  resource_changes: [
+    {
+      address: 'local_file.fake_file',
+      type: 'local_file',
+      name: 'fake_file',
+      change: {
+        actions: [Action.delete, Action.create]
+      }
+    }
+  ]
+}
 process.env['GITHUB_REPOSITORY'] = 'https://github.com/byu-oit/github-action-tf-plan-comment'
 
 test('Test Basic Plan Summary', async () => {
@@ -17,20 +29,13 @@ test('Test Basic Plan Summary', async () => {
       html_url: 'https://test/workflow/url'
     })
 
-  const commenter = new PlanCommenter(github.getOctokit('fake'), 1234, pr)
-  const plan: TerraformPlan = {
-    resource_changes: [
-      {
-        address: 'local_file.fake_file',
-        type: 'local_file',
-        name: 'fake_file',
-        change: {
-          actions: [Action.delete, Action.create]
-        }
-      }
-    ]
-  }
-  const summary = await commenter.planSummaryBody(plan)
+  const commenter = new PlanCommenter({
+    octokit: github.getOctokit('fake'),
+    runId: 1234,
+    pr
+  })
+
+  const summary = await commenter.planSummaryBody(basicTestPlan)
   const expected = `## Terraform Plan:
 will **replace (delete then create)** 1 resource: 
   * local_file - fake_file
@@ -42,10 +47,39 @@ will **replace (delete then create)** 1 resource:
 })
 
 test('Test Empty Plan Summary', async () => {
-  const commenter = new PlanCommenter(github.getOctokit('fake'), 1234, pr)
+  const commenter = new PlanCommenter({
+    octokit: github.getOctokit('fake'),
+    runId: 1234,
+    pr
+  })
   const emptyPlan: TerraformPlan = {}
   const summary = await commenter.planSummaryBody(emptyPlan)
   const expected = `## Terraform Plan:
 No changes detected`
   expect(summary).toEqual(expected)
+})
+
+test('Test Basic Plan with custom title', async () => {
+  const scope = nock('https://api.github.com')
+    .get(/.*/)
+    .reply(200, {
+      html_url: 'https://test/workflow/url'
+    })
+
+  const commenter = new PlanCommenter({
+    octokit: github.getOctokit('fake'),
+    runId: 1234,
+    pr,
+    commentTitle: 'Test Plan Title'
+  })
+
+  const summary = await commenter.planSummaryBody(basicTestPlan)
+  const expected = `## Test Plan Title:
+will **replace (delete then create)** 1 resource: 
+  * local_file - fake_file
+
+[see details](https://test/workflow/url)`
+  expect(summary).toEqual(expected)
+
+  scope.done()
 })

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     required: false
     description: Directory of the terraform configuration
     default: .
+  comment-title:
+    required: false
+    description: Title of the comment
+    default: Terraform Plan
 runs:
   using: 'node12'
   main: 'dist/index.js'


### PR DESCRIPTION
Added ability to specify the comment title. This allows for one PR that might have multiple terraform plan comments (I know it usually won't happen, but I've run into wanting two different plans on one PR in building the terraform-aws-postman-test-lambda module)